### PR TITLE
merge upstream

### DIFF
--- a/server/block/blast_furnace.go
+++ b/server/block/blast_furnace.go
@@ -46,6 +46,14 @@ func (b BlastFurnace) Tick(_ int64, pos cube.Pos, tx *world.Tx) {
 	}
 }
 
+// LightEmissionLevel ...
+func (b BlastFurnace) LightEmissionLevel() uint8 {
+	if b.Lit {
+		return 13
+	}
+	return 0
+}
+
 // EncodeItem ...
 func (b BlastFurnace) EncodeItem() (name string, meta int16) {
 	return "minecraft:blast_furnace", 0

--- a/server/block/cube/trace/bbox.go
+++ b/server/block/cube/trace/bbox.go
@@ -99,6 +99,41 @@ func BBoxIntercept(bb cube.BBox, start, end mgl64.Vec3) (result BBoxResult, ok b
 	return BBoxResult{bb: bb, pos: *vec, face: f}, true
 }
 
+// BBoxIntersects checks if the line segment from start to end intersects the BBox.
+// Unlike BBoxIntercept, it only reports whether an intersection exists and does not
+// calculate the closest hit position or face.
+func BBoxIntersects(bb cube.BBox, start, end mgl64.Vec3) bool {
+	min, max := bb.Min(), bb.Max()
+	dir := end.Sub(start)
+	tMin, tMax := 0.0, 1.0
+
+	for axis := range 3 {
+		if mgl64.FloatEqual(dir[axis], 0) {
+			if start[axis] < min[axis] || start[axis] > max[axis] {
+				return false
+			}
+			continue
+		}
+
+		inv := 1 / dir[axis]
+		t1 := (min[axis] - start[axis]) * inv
+		t2 := (max[axis] - start[axis]) * inv
+		if t1 > t2 {
+			t1, t2 = t2, t1
+		}
+		if t1 > tMin {
+			tMin = t1
+		}
+		if t2 < tMax {
+			tMax = t2
+		}
+		if tMin > tMax {
+			return false
+		}
+	}
+	return true
+}
+
 // vec3OnLineWithX returns an mgl64.Vec3 on the line between mgl64.Vec3 a and b with an X value passed. If no such vec3
 // could be found, the bool returned is false.
 func vec3OnLineWithX(a, b mgl64.Vec3, x float64) *mgl64.Vec3 {

--- a/server/block/cube/trace/block.go
+++ b/server/block/cube/trace/block.go
@@ -2,6 +2,7 @@ package trace
 
 import (
 	"github.com/df-mc/dragonfly/server/block/cube"
+	"github.com/df-mc/dragonfly/server/block/model"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/go-gl/mathgl/mgl64"
 	"math"
@@ -69,4 +70,24 @@ func BlockIntercept(pos cube.Pos, src world.BlockSource, b world.Block, start, e
 	}
 
 	return BlockResult{bb: hit.BBox(), pos: hit.Position(), face: hit.Face(), blockPos: pos}, true
+}
+
+// BlockIntersects checks if the line segment from start to end intersects the block model of b at pos. Unlike
+// BlockIntercept, it only reports whether an intersection exists and does not calculate the closest hit position, face,
+// or bounding box.
+func BlockIntersects(pos cube.Pos, src world.BlockSource, b world.Block, start, end mgl64.Vec3) bool {
+	m := b.Model()
+	switch m.(type) {
+	case model.Empty:
+		return false
+	case model.Solid:
+		return BBoxIntersects(cube.Box(0, 0, 0, 1, 1, 1).Translate(pos.Vec3()), start, end)
+	}
+
+	for _, bb := range m.BBox(pos, src) {
+		if BBoxIntersects(bb.Translate(pos.Vec3()), start, end) {
+			return true
+		}
+	}
+	return false
 }

--- a/server/block/furnace.go
+++ b/server/block/furnace.go
@@ -45,6 +45,14 @@ func (f Furnace) Tick(_ int64, pos cube.Pos, tx *world.Tx) {
 	}
 }
 
+// LightEmissionLevel ...
+func (f Furnace) LightEmissionLevel() uint8 {
+	if f.Lit {
+		return 13
+	}
+	return 0
+}
+
 // EncodeItem ...
 func (f Furnace) EncodeItem() (name string, meta int16) {
 	return "minecraft:furnace", 0

--- a/server/block/smoker.go
+++ b/server/block/smoker.go
@@ -46,6 +46,14 @@ func (s Smoker) Tick(_ int64, pos cube.Pos, tx *world.Tx) {
 	}
 }
 
+// LightEmissionLevel ...
+func (s Smoker) LightEmissionLevel() uint8 {
+	if s.Lit {
+		return 13
+	}
+	return 0
+}
+
 // EncodeItem ...
 func (s Smoker) EncodeItem() (name string, meta int16) {
 	return "minecraft:smoker", 0

--- a/server/entity/projectile.go
+++ b/server/entity/projectile.go
@@ -1,6 +1,12 @@
 package entity
 
 import (
+	"iter"
+	"math"
+	"math/rand/v2"
+	"slices"
+	"time"
+
 	"github.com/df-mc/dragonfly/server/block"
 	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/df-mc/dragonfly/server/block/cube/trace"
@@ -9,10 +15,6 @@ import (
 	"github.com/df-mc/dragonfly/server/item/potion"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/go-gl/mathgl/mgl64"
-	"iter"
-	"math"
-	"math/rand/v2"
-	"time"
 )
 
 // ProjectileBehaviourConfig allows the configuration of projectiles. Calling
@@ -80,6 +82,10 @@ type ProjectileBehaviourConfig struct {
 	// CollisionPosition specifies the position that the projectile is stuck
 	// in. If non-empty, the entity will not move.
 	CollisionPosition cube.Pos
+	// PiercingLevel is the crossbow Piercing enchantment level. The projectile
+	// passes through PiercingLevel entities and damages PiercingLevel+1 in
+	// total. A value of 0 means no piercing.
+	PiercingLevel int
 }
 
 func (conf ProjectileBehaviourConfig) Apply(data *world.EntityData) {
@@ -109,6 +115,8 @@ type ProjectileBehaviour struct {
 
 	collisionPos cube.Pos
 	collided     bool
+
+	collidedEntities []*world.EntityHandle
 }
 
 // Owner returns the owner of the projectile.
@@ -168,8 +176,11 @@ func (lt *ProjectileBehaviour) Tick(e *Ent, tx *world.Tx) *Movement {
 
 	switch r := result.(type) {
 	case trace.EntityResult:
-		if l, ok := r.Entity().(Living); ok && lt.conf.Damage >= 0 {
-			lt.hitEntity(l, e, vel)
+		if l, ok := r.Entity().(Living); ok {
+			if lt.conf.Damage >= 0 {
+				lt.hitEntity(l, e, vel)
+			}
+			lt.collidedEntities = append(lt.collidedEntities, l.H())
 		}
 	case trace.BlockResult:
 		bpos := r.BlockPosition()
@@ -180,12 +191,15 @@ func (lt *ProjectileBehaviour) Tick(e *Ent, tx *world.Tx) *Movement {
 			lt.hitBlockSurviving(e, r, m, tx)
 			return m
 		}
+		lt.close = true
 	}
 	if lt.conf.Hit != nil {
 		lt.conf.Hit(e, tx, result)
 	}
 
-	lt.close = true
+	if len(lt.collidedEntities) > lt.conf.PiercingLevel {
+		lt.close = true
+	}
 	return m
 }
 
@@ -264,6 +278,7 @@ func (lt *ProjectileBehaviour) hitEntity(l Living, e *Ent, vel mgl64.Vec3) {
 	if lt.conf.Critical {
 		dmg += rand.Float64() * dmg / 2
 	}
+	// TODO: Piercing arrows should bypass shield blocking when shields are implemented.
 	if _, vulnerable := l.Hurt(dmg, src); vulnerable {
 		l.KnockBack(l.Position().Sub(vel), 0.45+lt.conf.KnockBackForceAddend, 0.3608+lt.conf.KnockBackHeightAddend)
 
@@ -312,7 +327,7 @@ func (lt *ProjectileBehaviour) tickMovement(e *Ent, tx *world.Tx) (*Movement, tr
 				mx, my, mz := hit.Face().Axis().Vec3().Mul(-2).Add(mgl64.Vec3{1, 1, 1}).Elem()
 
 				vel = mgl64.Vec3{x * mx, y * my, z * mz}
-			} else {
+			} else if lt.conf.PiercingLevel == 0 {
 				vel = zeroVec3
 			}
 			end = hit.Position()
@@ -322,15 +337,19 @@ func (lt *ProjectileBehaviour) tickMovement(e *Ent, tx *world.Tx) (*Movement, tr
 }
 
 // ignores returns a function to ignore entities in trace.Perform that are
-// either a spectator, not living, the entity itself or its owner in the first
-// 5 ticks.
+// either a spectator, not living, the entity itself, its owner in the first
+// 5 ticks, or an entity it already collided with.
 func (lt *ProjectileBehaviour) ignores(e *Ent) trace.EntityFilter {
 	return func(seq iter.Seq[world.Entity]) iter.Seq[world.Entity] {
 		return func(yield func(world.Entity) bool) {
 			for other := range seq {
 				g, ok := other.(interface{ GameMode() world.GameMode })
+				spectator := ok && !g.GameMode().HasCollision()
+				itself := e.H() == other.H()
 				_, living := other.(Living)
-				if (ok && !g.GameMode().HasCollision()) || e.H() == other.H() || !living || (e.data.Age < time.Second/4 && lt.conf.Owner == other.H()) {
+				owner := e.data.Age < time.Second/4 && lt.conf.Owner == other.H()
+				collidedEntity := slices.Contains(lt.collidedEntities, other.H())
+				if spectator || itself || !living || owner || collidedEntity {
 					continue
 				}
 				if !yield(other) {

--- a/server/entity/register.go
+++ b/server/entity/register.go
@@ -47,15 +47,17 @@ var conf = world.EntityRegistryConfig{
 	SplashPotion: func(opts world.EntitySpawnOpts, t any, owner world.Entity) *world.EntityHandle {
 		return NewSplashPotion(opts, t.(potion.Potion), owner)
 	},
-	Arrow: func(opts world.EntitySpawnOpts, damage float64, owner world.Entity, critical, disallowPickup, obtainArrowOnPickup bool, punchLevel int, tip any) *world.EntityHandle {
+	Arrow: func(opts world.EntitySpawnOpts, arrow world.ArrowSpawnConfig) *world.EntityHandle {
+		tip := arrow.Tip.(potion.Potion)
 		conf := arrowConf
-		conf.Damage, conf.Potion, conf.Owner = damage, tip.(potion.Potion), owner.H()
-		conf.KnockBackForceAddend = float64(punchLevel) * enchantment.Punch.KnockBackMultiplier()
-		conf.DisablePickup = disallowPickup
-		if obtainArrowOnPickup {
-			conf.PickupItem = item.NewStack(item.Arrow{Tip: tip.(potion.Potion)}, 1)
+		conf.Damage, conf.Potion, conf.Owner = arrow.Damage, tip, arrow.Owner.H()
+		conf.KnockBackForceAddend = float64(arrow.PunchLevel) * enchantment.Punch.KnockBackMultiplier()
+		conf.DisablePickup = arrow.DisablePickup
+		if arrow.ObtainArrowOnPickup {
+			conf.PickupItem = item.NewStack(item.Arrow{Tip: tip}, 1)
 		}
-		conf.Critical = critical
+		conf.Critical = arrow.Critical
+		conf.PiercingLevel = arrow.PiercingLevel
 		return opts.New(ArrowType, conf)
 	},
 }

--- a/server/item/bow.go
+++ b/server/item/bow.go
@@ -78,8 +78,19 @@ func (Bow) Release(releaser Releaser, tx *world.Tx, ctx *UseContext, duration ti
 	}
 
 	create := tx.World().EntityRegistry().Config().Arrow
-	opts := world.EntitySpawnOpts{Position: eyePosition(releaser), Velocity: releaser.Rotation().Vec3().Mul(force * 5), Rotation: releaser.Rotation().Neg()}
-	projectile := tx.AddEntity(create(opts, damage, releaser, force >= 1, false, !creative && consume, punchLevel, tip))
+	opts := world.EntitySpawnOpts{
+		Position: eyePosition(releaser),
+		Velocity: releaser.Rotation().Vec3().Mul(force * 5),
+		Rotation: releaser.Rotation().Neg(),
+	}
+	projectile := tx.AddEntity(create(opts, world.ArrowSpawnConfig{
+		Damage:              damage,
+		Owner:               releaser,
+		Critical:            force >= 1,
+		ObtainArrowOnPickup: !creative && consume,
+		PunchLevel:          punchLevel,
+		Tip:                 tip,
+	}))
 	if f, ok := projectile.(interface{ SetOnFire(duration time.Duration) }); ok {
 		f.SetOnFire(burnDuration)
 	}

--- a/server/item/crossbow.go
+++ b/server/item/crossbow.go
@@ -122,18 +122,27 @@ func (c Crossbow) ReleaseCharge(releaser Releaser, tx *world.Tx, ctx *UseContext
 	held, _ := releaser.HeldItems()
 	creative := releaser.GameMode().CreativeInventory()
 
-	multishot := false
+	pierceLevel, multishot := 0, false
 	for _, enchant := range held.Enchantments() {
 		if _, ok := enchant.Type().(interface{ MultipleProjectiles() bool }); ok {
 			multishot = true
-			break
+		}
+		if _, ok := enchant.Type().(interface{ Pierces() bool }); ok {
+			pierceLevel = enchant.Level()
 		}
 	}
 
-	c.shoot(releaser, tx, 0, !creative)
+	arrowConf := world.ArrowSpawnConfig{
+		Damage:              9,
+		Owner:               releaser,
+		ObtainArrowOnPickup: !creative,
+		PiercingLevel:       pierceLevel,
+	}
+	c.shoot(releaser, tx, 0, arrowConf)
 	if multishot {
-		c.shoot(releaser, tx, -10, false)
-		c.shoot(releaser, tx, 10, false)
+		arrowConf.ObtainArrowOnPickup = false
+		c.shoot(releaser, tx, -10, arrowConf)
+		c.shoot(releaser, tx, 10, arrowConf)
 	}
 	c.applyDamage(ctx)
 
@@ -146,7 +155,7 @@ func (c Crossbow) ReleaseCharge(releaser Releaser, tx *world.Tx, ctx *UseContext
 }
 
 // shoot fires the crossbow's loaded projectiles.
-func (c Crossbow) shoot(releaser Releaser, tx *world.Tx, offsetAngle float64, canObtainPickup bool) {
+func (c Crossbow) shoot(releaser Releaser, tx *world.Tx, offsetAngle float64, arrowConf world.ArrowSpawnConfig) {
 	rot := releaser.Rotation()
 	dirVec := cube.Rotation{rot[0] + offsetAngle, rot[1]}.Vec3()
 
@@ -160,11 +169,12 @@ func (c Crossbow) shoot(releaser Releaser, tx *world.Tx, offsetAngle float64, ca
 		tx.AddEntity(projectile)
 	} else {
 		createArrow := tx.World().EntityRegistry().Config().Arrow
+		arrowConf.Tip = c.Item.Item().(Arrow).Tip
 		arrow := createArrow(world.EntitySpawnOpts{
 			Position: torsoPosition(releaser),
 			Velocity: dirVec.Mul(5.15),
 			Rotation: rot.Neg(),
-		}, 9, releaser, false, false, canObtainPickup, 0, c.Item.Item().(Arrow).Tip)
+		}, arrowConf)
 		tx.AddEntity(arrow)
 	}
 }

--- a/server/item/enchantment/multishot.go
+++ b/server/item/enchantment/multishot.go
@@ -32,8 +32,7 @@ func (multishot) Rarity() item.EnchantmentRarity {
 
 // CompatibleWithEnchantment ...
 func (multishot) CompatibleWithEnchantment(t item.EnchantmentType) bool {
-	// TODO: Multishot is incompatible with Piercing
-	return true
+	return t != Piercing
 }
 
 // CompatibleWithItem ...

--- a/server/item/enchantment/piercing.go
+++ b/server/item/enchantment/piercing.go
@@ -1,0 +1,40 @@
+package enchantment
+
+import (
+	"github.com/df-mc/dragonfly/server/item"
+	"github.com/df-mc/dragonfly/server/world"
+)
+
+// Piercing is an enchantment that allows arrows to damage and pierce through multiple entities, including shields.
+var Piercing piercing
+
+type piercing struct{}
+
+func (p piercing) Name() string {
+	return "Piercing"
+}
+
+func (p piercing) MaxLevel() int {
+	return 4
+}
+
+func (p piercing) Cost(level int) (int, int) {
+	return 1 + (level-1)*10, 50
+}
+
+func (p piercing) Rarity() item.EnchantmentRarity {
+	return item.EnchantmentRarityCommon
+}
+
+func (p piercing) CompatibleWithEnchantment(t item.EnchantmentType) bool {
+	return t != Multishot
+}
+
+func (p piercing) CompatibleWithItem(i world.Item) bool {
+	_, ok := i.(item.Crossbow)
+	return ok
+}
+
+func (p piercing) Pierces() bool {
+	return true
+}

--- a/server/item/enchantment/register.go
+++ b/server/item/enchantment/register.go
@@ -37,7 +37,7 @@ func init() {
 	// TODO: (31) Loyalty.
 	// TODO: (32) Channeling.
 	item.RegisterEnchantment(33, Multishot)
-	// TODO: (34) Piercing.
+	item.RegisterEnchantment(34, Piercing)
 	item.RegisterEnchantment(35, QuickCharge)
 	item.RegisterEnchantment(36, SoulSpeed)
 	item.RegisterEnchantment(37, SwiftSneak)

--- a/server/item/golden_apple.go
+++ b/server/item/golden_apple.go
@@ -22,7 +22,9 @@ func (e GoldenApple) ConsumeDuration() time.Duration {
 // Consume ...
 func (e GoldenApple) Consume(_ *world.Tx, c Consumer) Stack {
 	c.Saturate(4, 9.6)
+	prev := c.Absorption()
 	c.AddEffect(effect.New(effect.Absorption, 1, 2*time.Minute))
+	c.SetAbsorption(max(prev, min(prev+4, 16)))
 	c.AddEffect(effect.New(effect.Regeneration, 2, 5*time.Second))
 	return Stack{}
 }

--- a/server/item/item.go
+++ b/server/item/item.go
@@ -91,6 +91,11 @@ type Consumer interface {
 	// Effects returns any effect currently applied to the Consumer. The returned effects are guaranteed not to have
 	// expired when returned.
 	Effects() []effect.Effect
+	// Absorption returns the absorption health of the Consumer.
+	Absorption() float64
+	// SetAbsorption sets the absorption health of the Consumer. Absorption health is shown as golden hearts and does
+	// not regenerate naturally.
+	SetAbsorption(health float64)
 }
 
 // DefaultConsumeDuration is the default duration that consuming an item takes. Dried kelp takes half this

--- a/server/item/stack.go
+++ b/server/item/stack.go
@@ -276,6 +276,21 @@ func (s Stack) WithEnchantments(enchants ...Enchantment) Stack {
 			// Enchantment is not compatible with the item.
 			continue
 		}
+		compatible := true
+		for _, otherEnchant := range s.enchantments {
+			addingType := enchant.t
+			existingType := otherEnchant.Type()
+			addingAcceptsExisting := addingType.CompatibleWithEnchantment(existingType)
+			existingAcceptsAdding := existingType.CompatibleWithEnchantment(addingType)
+			if addingType != existingType && (!addingAcceptsExisting || !existingAcceptsAdding) {
+				compatible = false
+				break
+			}
+		}
+		if !compatible {
+			// Enchantment is not compatible with another enchantment on the item.
+			continue
+		}
 		s.enchantments[enchant.t] = enchant
 	}
 	return s

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -602,8 +602,12 @@ func (p *Player) Hurt(dmg float64, src world.DamageSource) (float64, bool) {
 	p.setAttackImmunity(immunity, totalDamage)
 
 	if a := p.Absorption(); a > 0 {
-		p.SetAbsorption(a - damageLeft)
+		remaining := a - damageLeft
+		p.SetAbsorption(remaining)
 		damageLeft = max(0, damageLeft-a)
+		if _, exists := p.Effect(effect.Absorption); exists && remaining <= 0 {
+			p.RemoveEffect(effect.Absorption)
+		}
 	}
 
 	if p.Health()-damageLeft <= mgl64.Epsilon && !src.IgnoreTotem() {

--- a/server/world/block_registry.go
+++ b/server/world/block_registry.go
@@ -62,6 +62,8 @@ type BlockRegistry interface {
 	// BlockHash returns a unique identifier of the block including the block states. The hash is internal to Dragonfly
 	// and is used for fast map lookups; it does not need to match any in-game identifiers.
 	BlockHash(b Block) uint64
+	// RuntimeIDToHash resolves a runtime ID to its network block hash.
+	RuntimeIDToHash(runtimeID uint32) (hash uint32, ok bool)
 }
 
 const (
@@ -117,6 +119,7 @@ type BasicBlockRegistry struct {
 	bitSize           int
 	hashes            *intintmap.Map
 	networkhashToRids map[uint32]uint32
+	ridsToNetworkhash []uint32
 
 	// stateRuntimeIDs holds a map for looking up the runtime ID of a block by the stateHash it produces.
 	stateRuntimeIDs map[stateHash]uint32
@@ -204,6 +207,16 @@ func (br *BasicBlockRegistry) HashToRuntimeID(hash uint32) (rid uint32, ok bool)
 	return
 }
 
+func (br *BasicBlockRegistry) RuntimeIDToHash(runtimeID uint32) (hash uint32, ok bool) {
+	if !br.finalized {
+		panic("BlockRegistry.RuntimeIDToHash called on non finalized BlockRegistry")
+	}
+	if runtimeID >= uint32(len(br.ridsToNetworkhash)) {
+		return 0, false
+	}
+	return br.ridsToNetworkhash[runtimeID], true
+}
+
 // Clone returns an independent copy of the registry. If the source registry is finalized, the clone is also finalized.
 // If the source is not finalized, the clone remains mutable.
 func (br *BasicBlockRegistry) Clone() *BasicBlockRegistry {
@@ -239,6 +252,7 @@ func (br *BasicBlockRegistry) Clone() *BasicBlockRegistry {
 		}
 		br2.networkhashToRids = make(map[uint32]uint32, len(br.networkhashToRids))
 		maps.Copy(br2.networkhashToRids, br.networkhashToRids)
+		br2.ridsToNetworkhash = append([]uint32(nil), br.ridsToNetworkhash...)
 	}
 
 	return br2
@@ -255,6 +269,7 @@ func NewBlockRegistry() BlockRegistry {
 	br.bitSize = 0
 	br.hashes = nil
 	br.networkhashToRids = nil
+	br.ridsToNetworkhash = nil
 	br.blockInfos = nil
 	return br
 }
@@ -344,6 +359,7 @@ func (br *BasicBlockRegistry) Finalize() {
 	br.blockInfos = make([]blockInfo, len(br.blocks))
 	br.hashes = intintmap.New(len(br.blocks), 0.999)
 	br.networkhashToRids = make(map[uint32]uint32, len(br.blocks))
+	br.ridsToNetworkhash = make([]uint32, len(br.blocks))
 	br.stateRuntimeIDs = make(map[stateHash]uint32, len(br.blocks))
 	networkHashScratch := make([]byte, 0, 0xff)
 	foundAir := false
@@ -398,6 +414,7 @@ func (br *BasicBlockRegistry) Finalize() {
 			panic(fmt.Sprintf("network block hash collision for (%s %+v) and (%s %+v)", name, properties, otherName, otherProperties))
 		}
 		br.networkhashToRids[netHash] = rid
+		br.ridsToNetworkhash[rid] = netHash
 	}
 	if !foundAir {
 		panic("BlockRegistry.Finalize: no minecraft:air block state registered")

--- a/server/world/chunk/chunk.go
+++ b/server/world/chunk/chunk.go
@@ -49,6 +49,26 @@ func New(br BlockRegistry, r cube.Range) *Chunk {
 	}
 }
 
+// Clone returns an independent copy of the Chunk.
+func (chunk *Chunk) Clone() *Chunk {
+	clone := &Chunk{
+		r:                    chunk.r,
+		br:                   chunk.br,
+		air:                  chunk.air,
+		recalculateHeightMap: chunk.recalculateHeightMap,
+		heightMap:            slices.Clone(chunk.heightMap),
+		sub:                  make([]*SubChunk, len(chunk.sub)),
+		biomes:               make([]*PalettedStorage, len(chunk.biomes)),
+	}
+	for i, sub := range chunk.sub {
+		clone.sub[i] = sub.Clone()
+	}
+	for i, biomes := range chunk.biomes {
+		clone.biomes[i] = biomes.Clone()
+	}
+	return clone
+}
+
 // Equals returns if the chunk passed is equal to the current one
 func (chunk *Chunk) Equals(c *Chunk) bool {
 	if !chunk.recalculateHeightMap && !c.recalculateHeightMap && !slices.Equal(c.heightMap, chunk.heightMap) {

--- a/server/world/chunk/light.go
+++ b/server/world/chunk/light.go
@@ -1,17 +1,13 @@
 package chunk
 
-import (
-	"container/list"
-
-	"github.com/df-mc/dragonfly/server/block/cube"
-)
+import "github.com/df-mc/dragonfly/server/block/cube"
 
 // insertBlockLightNodes iterates over the chunk and looks for blocks that have a light level of at least 1.
 // If one is found, a node is added for it to the node queue.
-func (a *lightArea) insertBlockLightNodes(queue *list.List) {
+func (a *lightArea) insertBlockLightNodes(queue *lightQueue) {
 	a.iterSubChunks(a.anyLightBlocks, func(pos cube.Pos) {
 		if level := a.highest(pos, a.br.LightBlock); level > 0 {
-			queue.PushBack(node(pos, level, BlockLight))
+			queue.push(node(pos, level, BlockLight))
 		}
 	})
 }
@@ -30,7 +26,7 @@ func (a *lightArea) anyLightBlocks(sub *SubChunk) bool {
 
 // insertSkyLightNodes iterates over the chunk and inserts a light node anywhere at the highest block in the
 // chunk. In addition, any skylight above those nodes will be set to 15.
-func (a *lightArea) insertSkyLightNodes(queue *list.List) {
+func (a *lightArea) insertSkyLightNodes(queue *lightQueue) {
 	a.iterHeightmap(func(x, z int, height, highestNeighbour, highestY, lowestY int) {
 		pos := cube.Pos{x, height, z}
 		if height <= a.r.Max() {
@@ -41,7 +37,7 @@ func (a *lightArea) insertSkyLightNodes(queue *list.List) {
 				if level := a.highest(pos.Sub(cube.Pos{0, 1}), a.br.FilteringBlock); level != 15 && level != 0 {
 					// If we hit a block like water or leaves (something that diffuses but does not block light), we
 					// need a node above this block regardless of the neighbours.
-					queue.PushBack(node(pos, 15, SkyLight))
+					queue.push(node(pos, 15, SkyLight))
 				}
 			}
 		}
@@ -50,7 +46,7 @@ func (a *lightArea) insertSkyLightNodes(queue *list.List) {
 			// lower than the current one, on the same Y level, or one level higher, because light in
 			// this column can't spread below that anyway.
 			if pos[1]++; pos[1] < highestNeighbour {
-				queue.PushBack(node(pos, 15, SkyLight))
+				queue.push(node(pos, 15, SkyLight))
 				continue
 			}
 			// Fill the rest with full skylight.
@@ -61,7 +57,7 @@ func (a *lightArea) insertSkyLightNodes(queue *list.List) {
 
 // insertLightSpreadingNodes inserts light nodes into the node queue passed which, when propagated, will
 // spread into the neighbouring chunks.
-func (a *lightArea) insertLightSpreadingNodes(queue *list.List, lt light) {
+func (a *lightArea) insertLightSpreadingNodes(queue *lightQueue, lt light) {
 	a.iterEdges(a.nodesNeeded(lt), func(pa, pb cube.Pos) {
 		la, lb := a.light(pa, lt), a.light(pb, lt)
 		if la == lb || la-1 == lb || lb-1 == la {
@@ -69,9 +65,9 @@ func (a *lightArea) insertLightSpreadingNodes(queue *list.List, lt light) {
 			return
 		}
 		if filter := a.highest(pb, a.br.FilteringBlock) + 1; la > filter && la-filter > lb {
-			queue.PushBack(node(pb, la-filter, lt))
+			queue.push(node(pb, la-filter, lt))
 		} else if filter = a.highest(pa, a.br.FilteringBlock) + 1; lb > filter && lb-filter > la {
-			queue.PushBack(node(pa, lb-filter, lt))
+			queue.push(node(pa, lb-filter, lt))
 		}
 	})
 }
@@ -92,19 +88,33 @@ func (a *lightArea) nodesNeeded(lt light) func(sa, sb *SubChunk) bool {
 
 // propagate spreads the next light node in the node queue passed through the lightArea a. propagate adds the neighbours
 // of the node to the queue for as long as it is able to spread.
-func (a *lightArea) propagate(queue *list.List) {
-	n := queue.Remove(queue.Front()).(lightNode)
+func (a *lightArea) propagate(queue *lightQueue) {
+	n, ok := queue.pop()
+	if !ok {
+		return
+	}
 	if a.light(n.pos, n.lt) >= n.level {
 		return
 	}
 	a.setLight(n.pos, n.lt, n.level)
 
-	for neighbour := range a.neighbours(n) {
-		filter := a.highest(neighbour.pos, a.br.FilteringBlock) + 1
-		if n.level > filter && a.light(neighbour.pos, n.lt) < n.level-filter {
-			neighbour.level = n.level - filter
-			queue.PushBack(neighbour)
-		}
+	x, y, z := n.pos[0], n.pos[1], n.pos[2]
+	a.propagateNeighbour(queue, n.lt, n.level, x+1, y, z)
+	a.propagateNeighbour(queue, n.lt, n.level, x-1, y, z)
+	a.propagateNeighbour(queue, n.lt, n.level, x, y+1, z)
+	a.propagateNeighbour(queue, n.lt, n.level, x, y-1, z)
+	a.propagateNeighbour(queue, n.lt, n.level, x, y, z+1)
+	a.propagateNeighbour(queue, n.lt, n.level, x, y, z-1)
+}
+
+func (a *lightArea) propagateNeighbour(queue *lightQueue, lt light, level uint8, x, y, z int) {
+	if y < a.r.Min() || y > a.r.Max() || x < a.baseX || z < a.baseZ || x >= a.baseX+a.w*16 || z >= a.baseZ+a.w*16 {
+		return
+	}
+	pos := cube.Pos{x, y, z}
+	filter := a.highest(pos, a.br.FilteringBlock) + 1
+	if level > filter && a.light(pos, lt) < level-filter {
+		queue.push(node(pos, level-filter, lt))
 	}
 }
 

--- a/server/world/chunk/light_area.go
+++ b/server/world/chunk/light_area.go
@@ -2,9 +2,6 @@ package chunk
 
 import (
 	"bytes"
-	"container/list"
-
-	"iter"
 	"math"
 
 	"github.com/df-mc/dragonfly/server/block/cube"
@@ -17,6 +14,67 @@ type lightArea struct {
 	c            []*Chunk
 	w            int
 	r            cube.Range
+}
+
+// lightQueue is a FIFO ring buffer used during light propagation.
+type lightQueue struct {
+	nodes []lightNode
+	head  int
+	tail  int
+	size  int
+}
+
+// initialLightQueueCapacity is the starting size for light propagation queues. A lightNode is 48 bytes on
+// 64-bit platforms, so 1024 entries cost about 48 KiB. This avoids the first grow/copy for busier lighting
+// runs while keeping the queue transient and able to grow for larger chunks.
+const initialLightQueueCapacity = 1024
+
+// newLightQueue creates an empty queue sized to capacity (at least 1).
+func newLightQueue(capacity int) *lightQueue {
+	if capacity < 1 {
+		capacity = 1
+	}
+	return &lightQueue{nodes: make([]lightNode, capacity)}
+}
+
+// push appends a node to the tail, growing storage if full.
+func (q *lightQueue) push(n lightNode) {
+	if q.size == len(q.nodes) {
+		q.grow()
+	}
+	q.nodes[q.tail] = n
+	q.tail = (q.tail + 1) % len(q.nodes)
+	q.size++
+}
+
+// pop removes and returns the oldest queued node.
+func (q *lightQueue) pop() (lightNode, bool) {
+	if q.size == 0 {
+		return lightNode{}, false
+	}
+	n := q.nodes[q.head]
+	q.head = (q.head + 1) % len(q.nodes)
+	q.size--
+	return n, true
+}
+
+// empty returns true when no nodes are queued.
+func (q *lightQueue) empty() bool {
+	return q.size == 0
+}
+
+// grow expands the ring buffer and reorders elements to start at index 0.
+func (q *lightQueue) grow() {
+	nodes := make([]lightNode, len(q.nodes)<<1)
+	if q.head < q.tail {
+		copy(nodes, q.nodes[q.head:q.tail])
+	} else {
+		n := copy(nodes, q.nodes[q.head:])
+		copy(nodes[n:], q.nodes[:q.tail])
+	}
+	q.head = 0
+	q.tail = q.size
+	q.nodes = nodes
 }
 
 // LightArea creates a lightArea with the lower corner of the lightArea at baseX and baseZ. The length of the Chunk
@@ -40,11 +98,11 @@ func LightArea(c []*Chunk, baseX, baseZ int) *lightArea {
 // individual chunks within the lightArea itself, without light crossing chunk borders.
 func (a *lightArea) Fill() {
 	a.initialiseLightSlices()
-	queue := list.New()
+	queue := newLightQueue(initialLightQueueCapacity)
 	a.insertBlockLightNodes(queue)
 	a.insertSkyLightNodes(queue)
 
-	for queue.Len() != 0 {
+	for !queue.empty() {
 		a.propagate(queue)
 	}
 }
@@ -53,11 +111,11 @@ func (a *lightArea) Fill() {
 // neighbouring chunks. The neighbouring chunks must have passed the light 'filling' stage before this
 // function is called for an lightArea that includes them.
 func (a *lightArea) Spread() {
-	queue := list.New()
+	queue := newLightQueue(initialLightQueueCapacity)
 	a.insertLightSpreadingNodes(queue, BlockLight)
 	a.insertLightSpreadingNodes(queue, SkyLight)
 
-	for queue.Len() != 0 {
+	for !queue.empty() {
 		a.propagate(queue)
 	}
 }
@@ -70,21 +128,6 @@ func (a *lightArea) light(pos cube.Pos, l light) uint8 {
 // light sets the light at a cube.Pos with the light type l.
 func (a *lightArea) setLight(pos cube.Pos, l light, v uint8) {
 	l.setLight(a.sub(pos), uint8(pos[0]&0xf), uint8(pos[1]&0xf), uint8(pos[2]&0xf), v)
-}
-
-// neighbours returns all neighbour lightNode of the one passed. If one of these nodes would otherwise fall outside the
-// lightArea, it is not returned.
-func (a *lightArea) neighbours(n lightNode) iter.Seq[lightNode] {
-	return func(yield func(lightNode) bool) {
-		for _, f := range cube.Faces() {
-			nn := lightNode{pos: n.pos.Side(f), lt: n.lt}
-			if nn.pos[1] <= a.r.Max() && nn.pos[1] >= a.r.Min() && nn.pos[0] >= a.baseX && nn.pos[2] >= a.baseZ && nn.pos[0] < a.baseX+a.w*16 && nn.pos[2] < a.baseZ+a.w*16 {
-				if !yield(nn) {
-					return
-				}
-			}
-		}
-	}
 }
 
 // iterSubChunks iterates over all blocks of the lightArea on a per-SubChunk basis. A filter function may be passed to

--- a/server/world/chunk/palette.go
+++ b/server/world/chunk/palette.go
@@ -2,6 +2,7 @@ package chunk
 
 import (
 	"math"
+	"slices"
 )
 
 // paletteSize is the size of a palette. It indicates the amount of bits occupied per value stored.
@@ -21,6 +22,16 @@ type Palette struct {
 // newPalette returns a new Palette with size and a slice of added values.
 func newPalette(size paletteSize, values []uint32) *Palette {
 	return &Palette{size: size, values: values, last: math.MaxUint32}
+}
+
+// Clone returns an independent copy of the Palette.
+func (palette *Palette) Clone() *Palette {
+	return &Palette{
+		last:      palette.last,
+		lastIndex: palette.lastIndex,
+		size:      palette.size,
+		values:    slices.Clone(palette.values),
+	}
 }
 
 // Len returns the amount of unique values in the Palette.

--- a/server/world/chunk/paletted_storage.go
+++ b/server/world/chunk/paletted_storage.go
@@ -2,6 +2,7 @@ package chunk
 
 import (
 	"bytes"
+	"slices"
 	"unsafe"
 )
 
@@ -57,6 +58,11 @@ func newPalettedStorage(indices []uint32, palette *Palette) *PalettedStorage {
 // emptyStorage creates a PalettedStorage filled completely with a value v.
 func emptyStorage(v uint32) *PalettedStorage {
 	return newPalettedStorage([]uint32{}, newPalette(0, []uint32{v}))
+}
+
+// Clone returns an independent copy of the PalettedStorage.
+func (storage *PalettedStorage) Clone() *PalettedStorage {
+	return newPalettedStorage(slices.Clone(storage.indices), storage.palette.Clone())
 }
 
 // Palette returns the Palette of the PalettedStorage.
@@ -164,7 +170,7 @@ func (storage *PalettedStorage) resize(newPaletteSize paletteSize) {
 // relatively heavy task which should only happen right before the sub chunk holding this PalettedStorage is
 // saved to disk. compact also shrinks the palette size if possible.
 func (storage *PalettedStorage) compact() {
-	if storage.palette == nil || storage.palette.Len() == 0 {
+	if storage.palette.Len() == 0 {
 		return
 	}
 	if storage.palette.Len() == 1 {

--- a/server/world/chunk/sub_chunk.go
+++ b/server/world/chunk/sub_chunk.go
@@ -1,5 +1,7 @@
 package chunk
 
+import "slices"
+
 // SubChunk is a cube of blocks located in a chunk. It has a size of 16x16x16 blocks and forms part of a stack
 // that forms a Chunk.
 type SubChunk struct {
@@ -27,6 +29,34 @@ func (sub *SubChunk) Equals(s *SubChunk) bool {
 // NewSubChunk creates a new sub chunk. All sub chunks should be created through this function.
 func NewSubChunk(air uint32) *SubChunk {
 	return &SubChunk{air: air}
+}
+
+// Clone returns an independent copy of the SubChunk.
+func (sub *SubChunk) Clone() *SubChunk {
+	clone := &SubChunk{
+		air:        sub.air,
+		storages:   make([]*PalettedStorage, len(sub.storages)),
+		blockLight: cloneLight(sub.blockLight),
+		skyLight:   cloneLight(sub.skyLight),
+	}
+	for i, storage := range sub.storages {
+		clone.storages[i] = storage.Clone()
+	}
+	return clone
+}
+
+func cloneLight(light []uint8) []uint8 {
+	if len(light) == 0 {
+		return slices.Clone(light)
+	}
+	switch &light[0] {
+	case noLightPtr:
+		return noLight
+	case fullLightPtr:
+		return fullLight
+	default:
+		return slices.Clone(light)
+	}
 }
 
 // Empty checks if the SubChunk is considered empty. This is the case if the SubChunk has 0 block storages or if it has

--- a/server/world/entity.go
+++ b/server/world/entity.go
@@ -366,7 +366,7 @@ type EntityRegistryConfig struct {
 	FallingBlock       func(opts EntitySpawnOpts, bl Block) *EntityHandle
 	TNT                func(opts EntitySpawnOpts, fuse time.Duration) *EntityHandle
 	BottleOfEnchanting func(opts EntitySpawnOpts, owner Entity) *EntityHandle
-	Arrow              func(opts EntitySpawnOpts, damage float64, owner Entity, critical, disallowPickup, obtainArrowOnPickup bool, punchLevel int, tip any) *EntityHandle
+	Arrow              func(opts EntitySpawnOpts, conf ArrowSpawnConfig) *EntityHandle
 	Egg                func(opts EntitySpawnOpts, owner Entity) *EntityHandle
 	EnderPearl         func(opts EntitySpawnOpts, owner Entity) *EntityHandle
 	Firework           func(opts EntitySpawnOpts, firework Item, owner Entity, sidewaysVelocityMultiplier, upwardsAcceleration float64, attached bool) *EntityHandle
@@ -374,6 +374,28 @@ type EntityRegistryConfig struct {
 	Snowball           func(opts EntitySpawnOpts, owner Entity) *EntityHandle
 	SplashPotion       func(opts EntitySpawnOpts, t any, owner Entity) *EntityHandle
 	Lightning          func(opts EntitySpawnOpts) *EntityHandle
+}
+
+// ArrowSpawnConfig holds the options used to spawn an arrow entity.
+type ArrowSpawnConfig struct {
+	// Damage specifies the base damage dealt by the arrow.
+	Damage float64
+	// Owner is the entity that fired the arrow.
+	Owner Entity
+	// Critical specifies if the arrow should deal critical damage.
+	Critical bool
+	// DisablePickup specifies if picking up the arrow should be disabled.
+	DisablePickup bool
+	// ObtainArrowOnPickup specifies if the arrow should be returned as an item when picked up.
+	ObtainArrowOnPickup bool
+	// PunchLevel specifies the level of punch knockback applied to the arrow.
+	PunchLevel int
+	// PiercingLevel is the crossbow Piercing enchantment level. The arrow passes
+	// through PiercingLevel entities and damages PiercingLevel+1 in total. A
+	// value of 0 means no piercing.
+	PiercingLevel int
+	// Tip specifies the potion tip carried by the arrow.
+	Tip any
 }
 
 // New creates an EntityRegistry using conf and the EntityTypes passed.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Projectile piercing, player damage/absorption, and lighting propagation are behavior-sensitive; the arrow spawn registry signature change may break custom entity registrations.
> 
> **Overview**
> This merge brings **crossbow Piercing** (new enchantment, mutual exclusion with Multishot), **projectiles that can hit multiple entities** before stopping, and a consolidated **`ArrowSpawnConfig`** for bow/crossbow/entity registration instead of a long positional API.
> 
> **Combat and items:** Golden apples now raise absorption with a capped bonus; the `Consumer` API exposes absorption health, and players clear the absorption effect when that pool is exhausted. `WithEnchantments` rejects enchant pairs that are incompatible with each other on the same stack.
> 
> **World simulation:** Lit **furnace**, **blast furnace**, and **smoker** emit block light (level 13). Chunk **sub-chunk/palette storage can be cloned** independently; the block registry adds **runtime ID → network hash** lookup. Lighting propagation drops `container/list` for a **ring-buffer queue** and inlines neighbor updates.
> 
> **Tracing:** **`BBoxIntersects`** / **`BlockIntersects`** answer segment–box hits without computing closest hit position/face.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb1a7a77d27272cbfb32a44801f42c782da1a8fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->